### PR TITLE
fix: include data directory in GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,11 @@ jobs:
           NEXT_TELEMETRY_DISABLED: 1
           CI: true
 
+      - name: Copy data directory to out directory
+        run: |
+          mkdir -p out/data
+          cp -r data/* out/data/
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
### **Description**
This PR fixes the 404 errors for the JSON and MD files by ensuring the `data` directory is included in the GitHub Pages deployment artifact. The files were previously inaccessible because the `data` directory was not being copied to the deployment directory (`out`).

---

### **Changes**
1. **Modified `deploy.yml` Workflow**:
   - Added a step to copy the `data` directory into the `out` directory before uploading the artifact.
   - This ensures that the `data` directory is included in the deployment and accessible under `https://elizaos.github.io/data/`.

2. **Impact**:
   - Resolves 404 errors for the following URLs:
     - `https://elizaos.github.io/data/daily/contributors.json`
     - `https://elizaos.github.io/data/daily/summary.json`
     - `https://elizaos.github.io/data/daily/summary.md`
     - `https://elizaos.github.io/data/weekly/contributors.json`
     - `https://elizaos.github.io/data/monthly/contributors.json`

---

### **Testing**
- **Manual Testing**:
  - Verified that the `data` directory is correctly copied to the `out` directory during the build process.
  - Confirmed that the JSON and MD files are accessible at the expected URLs after deployment.

- **Links from my repo**:  

  - https://xr0am.github.io/elizaos.github.io/data/daily/summary.json
  - https://xr0am.github.io/elizaos.github.io/data/daily/contributors.json
  - https://xr0am.github.io/elizaos.github.io/data/daily/summary.md
  - https://xr0am.github.io/elizaos.github.io/data/weekly/contributors.json
  - https://xr0am.github.io/elizaos.github.io/data/monthly/contributors.json

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions deployment workflow to include copying data directory during build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->