### PR TITLE
Fix: Use default branch for profile README edit link

### DIFF
--- a/src/app/profile/edit/components/ProfileEditor.tsx
+++ b/src/app/profile/edit/components/ProfileEditor.tsx
@@ -28,6 +28,7 @@ export default function ProfileEditor() {
     readmeContent,
     handleCreateProfileRepo,
     handleGenerateWalletSection,
+    defaultBranch,
   } = useProfileWallets();
 
   if (pageLoading && !user) {
@@ -108,6 +109,7 @@ export default function ProfileEditor() {
                   userLogin={userLogin}
                   walletSection={walletSection}
                   readmeContent={readmeContent}
+                  defaultBranch={defaultBranch}
                 />
               )}
             </>

--- a/src/app/profile/edit/components/WalletLinkBoard.tsx
+++ b/src/app/profile/edit/components/WalletLinkBoard.tsx
@@ -16,12 +16,14 @@ interface WalletLinkBoardProps {
   userLogin: string;
   walletSection: string;
   readmeContent: string | null;
+  defaultBranch: string;
 }
 
 export function WalletLinkBoard({
   userLogin,
   walletSection,
   readmeContent,
+  defaultBranch,
 }: WalletLinkBoardProps) {
   const [copied, copyToClipboard] = useCopyToClipboard();
 
@@ -33,14 +35,20 @@ export function WalletLinkBoard({
     // Always open GitHub regardless of copy success
     const githubUrl =
       readmeContent === null
-        ? `https://github.com/${userLogin}/${userLogin}/new/main?filename=README.md`
-        : `https://github.com/${userLogin}/${userLogin}/edit/main/README.md`;
+        ? `https://github.com/${userLogin}/${userLogin}/new/${defaultBranch}?filename=README.md`
+        : `https://github.com/${userLogin}/${userLogin}/edit/${defaultBranch}/README.md`;
 
     // Attempt to copy, but don't block GitHub opening
     await copyToClipboard(walletSection);
 
     window.open(githubUrl, "_blank");
-  }, [copyToClipboard, walletSection, userLogin, readmeContent]);
+  }, [
+    copyToClipboard,
+    walletSection,
+    userLogin,
+    readmeContent,
+    defaultBranch,
+  ]);
 
   return (
     <div className="space-y-4">

--- a/src/lib/walletLinking/useProfileWallets.ts
+++ b/src/lib/walletLinking/useProfileWallets.ts
@@ -24,6 +24,7 @@ export function useProfileWallets() {
   const [readmeContent, setReadmeContent] = useState<string | null>(null);
   const [walletData, setWalletData] = useState<WalletLinkingData | null>(null);
   const [walletSection, setWalletSection] = useState<string | null>(null);
+  const [defaultBranch, setDefaultBranch] = useState<string>("main");
 
   const [pageLoading, setPageLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -38,8 +39,12 @@ export function useProfileWallets() {
       const repoResponse = await fetch(repoUrl);
       if (!repoResponse.ok) {
         setProfileRepoExists(false);
+        // Default to 'main' if repo fetch fails or repo doesn't exist
+        setDefaultBranch("main");
         return;
       }
+      const repoData = await repoResponse.json();
+      setDefaultBranch(repoData.default_branch || "main");
       setProfileRepoExists(true);
 
       // check if the Readme exists
@@ -67,6 +72,8 @@ export function useProfileWallets() {
       setProfileRepoExists(null);
       setReadmeContent(null);
       setWalletData(null);
+      // Default to 'main' on error
+      setDefaultBranch("main");
     } finally {
       setPageLoading(false);
     }
@@ -170,5 +177,6 @@ export function useProfileWallets() {
     getWalletAddress,
     handleCreateProfileRepo,
     handleGenerateWalletSection,
+    defaultBranch,
   };
 }


### PR DESCRIPTION
Previously, the link to edit your profile README was hardcoded to use the 'main' branch. This change updates the logic to:

1. Fetch the actual default branch of your profile repository (e.g., username/username).
2. Use this fetched default branch name (e.g., 'master' or 'main') when constructing the URL to edit the README.md file.
3. If the profile repository doesn't exist or the default branch cannot be determined, it defaults to 'main' for creating a new README.md.

This ensures you are directed to the correct branch for your profile README, accommodating older repositories that might still use 'master' as the default.