### PR TITLE
fix UserProfile addresses fetching

### DIFF
--- a/src/lib/walletLinking/getUserWalletAddresses.ts
+++ b/src/lib/walletLinking/getUserWalletAddresses.ts
@@ -111,7 +111,10 @@ export async function getCachedUserWalletData(
           });
         }
         if (wallets.length > 0) {
-          return { wallets };
+          return {
+            wallets,
+            lastUpdated: userRecord.walletDataUpdatedAt.toString(),
+          };
         }
       }
       // Fresh cache, and we know there are no addresses, or only null addresses were stored.


### PR DESCRIPTION
#### This commit should resolve the current build Error for PR #124 

Fix the function getCachedUserWalletData's return type to include lastUpdated field, as required by WalletLinkingData interface.
```
return {
  wallets,
  lastUpdated: userRecord.walletDataUpdatedAt.toString(),
 };
```

For the UserProfile page, since the fetch was happening on the frontend inside user browser, the updated getCachedUserWalletData function, which includes server-side code accessing database, was causing the error. 
I've changed it to fetch user README directly from user browser without checking cache, as rate limit shouldn't be an issue in this case when it's a single request from the user browser for README content.

Perhaps another approach to fix this is to move the fetch server-side into queries.ts for UserProfile, same as Leaderboard.

