### PR TITLE
Add elizaos/docs repo tracking and claude bot exclusion

### DIFF
--- a/config/pipeline.config.ts
+++ b/config/pipeline.config.ts
@@ -33,6 +33,11 @@ export default {
       defaultBranch: "main",
     },
     {
+      owner: "elizaos",
+      name: "docs",
+      defaultBranch: "main",
+    },
+    {
       owner: "elizaos-plugins",
       name: "plugin-solana",
       defaultBranch: "1.x",
@@ -102,6 +107,7 @@ export default {
     "graphite-app",
     "google-labs-jules[bot]",
     "cursor",
+    "claude",
   ],
 
   // Scoring rules - controls how different contribution types are valued


### PR DESCRIPTION
## Summary
- Add elizaos/docs repository to the tracked repositories list for contributor analytics
- Add "claude" to bot users exclusion list to filter out Claude Code contributions from analytics

## Changes
- Added `elizaos/docs` repository with `main` as default branch to `repositories` array
- Added `"claude"` to `botUsers` array to exclude Claude Code contributions from scoring

## Test plan
- [ ] Verify pipeline configuration loads without errors
- [ ] Run pipeline ingest to test elizaos/docs repository tracking
- [ ] Confirm claude user contributions are properly filtered out

🤖 Generated with [Claude Code](https://claude.ai/code)