### PR TITLE
Update pipeline config: add 12 active repos

### DIFF
--- a/config/pipeline.config.ts
+++ b/config/pipeline.config.ts
@@ -17,15 +17,11 @@ export default {
   contributionStartDate: "2024-10-15",
   // Repositories to track
   repositories: [
+    // Core platform
     {
       owner: "elizaos",
       name: "eliza",
       defaultBranch: "main",
-    },
-    {
-      owner: "elizaos",
-      name: "auto.fun",
-      defaultBranch: "develop",
     },
     {
       owner: "elizaos",
@@ -37,6 +33,23 @@ export default {
       name: "docs",
       defaultBranch: "main",
     },
+    // Applications
+    {
+      owner: "elizaos",
+      name: "x402.elizaos.ai",
+      defaultBranch: "main",
+    },
+    {
+      owner: "elizaos",
+      name: "spartan",
+      defaultBranch: "main",
+    },
+    {
+      owner: "elizaos",
+      name: "jeju",
+      defaultBranch: "main",
+    },
+    // Plugins
     {
       owner: "elizaos-plugins",
       name: "plugin-solana",
@@ -46,6 +59,51 @@ export default {
       owner: "elizaos-plugins",
       name: "plugin-knowledge",
       defaultBranch: "1.x",
+    },
+    {
+      owner: "elizaos-plugins",
+      name: "plugin-chart",
+      defaultBranch: "main",
+    },
+    {
+      owner: "elizaos-plugins",
+      name: "plugin-analytics",
+      defaultBranch: "main",
+    },
+    {
+      owner: "elizaos-plugins",
+      name: "plugin-jupiter",
+      defaultBranch: "1.x",
+    },
+    {
+      owner: "elizaos-plugins",
+      name: "plugin-trust",
+      defaultBranch: "1.x",
+    },
+    {
+      owner: "elizaos-plugins",
+      name: "plugin-rolodex",
+      defaultBranch: "1.x",
+    },
+    {
+      owner: "elizaos-plugins",
+      name: "plugin-birdeye",
+      defaultBranch: "1.x",
+    },
+    {
+      owner: "elizaos-plugins",
+      name: "plugin-digitaltwin",
+      defaultBranch: "main",
+    },
+    {
+      owner: "elizaos-plugins",
+      name: "plugin-mysql",
+      defaultBranch: "main",
+    },
+    {
+      owner: "elizaos-plugins",
+      name: "plugin-elizaos-cloud",
+      defaultBranch: "main",
     },
     {
       owner: "elizaos-plugins",


### PR DESCRIPTION
Adds 12 actively maintained repositories based on CSV analysis of recent activity:

**Added:**
- 3 elizaOS repos: x402.elizaos.ai, spartan, jeju
- 9 plugins: chart, analytics, jupiter, trust, rolodex, birdeye, digitaltwin, mysql, elizaos-cloud

**Removed:**
- auto.fun (stale since June 2025)

All repos verified active with commits since Oct 2024.