### PR TITLE
feat: read SITE_NAME from pipeline config file

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,12 +100,23 @@ jobs:
         run: |
           REPO_NAME="${{ github.event.repository.name }}"
           OWNER="${{ github.repository_owner }}"
+          CONFIG_FILE="${{ env.PIPELINE_CONFIG_FILE }}"
+
+          # Auto-detect base path and site URL
           if [[ "$REPO_NAME" == *.github.io ]]; then
             echo "site_url=https://${OWNER}.github.io" >> $GITHUB_OUTPUT
             echo "base_path=" >> $GITHUB_OUTPUT
           else
             echo "site_url=https://${OWNER}.github.io/${REPO_NAME}" >> $GITHUB_OUTPUT
             echo "base_path=/${REPO_NAME}" >> $GITHUB_OUTPUT
+          fi
+
+          # Read SITE_NAME from config file if it exists
+          if [[ -f "$CONFIG_FILE" ]]; then
+            SITE_NAME=$(jq -r '.SITE_NAME // empty' "$CONFIG_FILE")
+            if [[ -n "$SITE_NAME" ]]; then
+              echo "site_name=$SITE_NAME" >> $GITHUB_OUTPUT
+            fi
           fi
 
       - name: Build Next.js app
@@ -116,8 +127,8 @@ jobs:
           BASE_PATH: ${{ secrets.BASE_PATH || steps.site-config.outputs.base_path }}
           NEXT_PUBLIC_BASE_PATH: ${{ secrets.BASE_PATH || steps.site-config.outputs.base_path }}
           SITE_URL: ${{ secrets.SITE_URL || steps.site-config.outputs.site_url }}
-          SITE_NAME: ${{ secrets.SITE_NAME || github.repository_owner }}
-          NEXT_PUBLIC_SITE_NAME: ${{ secrets.SITE_NAME || github.repository_owner }}
+          SITE_NAME: ${{ secrets.SITE_NAME || steps.site-config.outputs.site_name || github.repository_owner }}
+          NEXT_PUBLIC_SITE_NAME: ${{ secrets.SITE_NAME || steps.site-config.outputs.site_name || github.repository_owner }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEXT_PUBLIC_GITHUB_CLIENT_ID: ${{ secrets.NEXT_PUBLIC_GITHUB_CLIENT_ID }}
           NEXT_PUBLIC_AUTH_WORKER_URL: ${{ secrets.NEXT_PUBLIC_AUTH_WORKER_URL }}


### PR DESCRIPTION
## Summary

Allows forks to configure `SITE_NAME` via their pipeline config JSON file instead of requiring a GitHub secret.

## Changes

Updates `deploy.yml` to read `SITE_NAME` from the pipeline config file (e.g., `config/myorg.json`). The fallback chain is:

1. `SITE_NAME` secret (highest priority)
2. `SITE_NAME` from pipeline config file  
3. Repository owner name (fallback)

## Why

This is consistent with how `BASE_PATH` and `SITE_URL` are already auto-detected, making fork setup simpler. Forks can now set their custom site name in their config file without needing to configure a GitHub secret.

## Example Config

```json
{
  "SITE_NAME": "My Org",
  "PIPELINE_START_DATE": "2024-01-01",
  "repositories": [...]
}
```

## Test Plan

- [x] Tested on fork with `config/optimism.json` containing `SITE_NAME`
- [x] Verified fallback to repo owner when config doesn't have `SITE_NAME`
- [x] Verified secret still takes priority if set

🤖 Generated with [Claude Code](https://claude.com/claude-code)