### PR TITLE
feat: add profile copy button and rename site to HiScores

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,7 +8,7 @@ import { AuthProvider } from "@/contexts/AuthContext";
 
 const inter = Inter({ subsets: ["latin"] });
 
-const siteName = process.env.NEXT_PUBLIC_SITE_NAME || "Contributor Analytics";
+const siteName = process.env.NEXT_PUBLIC_SITE_NAME || "HiScores";
 
 export const metadata: Metadata = {
   title: siteName,

--- a/src/app/profile/[username]/components/UserProfile.tsx
+++ b/src/app/profile/[username]/components/UserProfile.tsx
@@ -11,6 +11,7 @@ import { DailyActivity } from "@/components/daily-activity";
 import { UserActivityHeatmap } from "@/lib/scoring/queries";
 import { SummaryCard, Summary } from "@/components/summary-card";
 import { WalletAddressBadge } from "@/components/ui/WalletAddressBadge";
+import { ProfileCopyButton } from "@/components/ui/profile-copy-button";
 import {
   UserBadge,
   getTierDefinition,
@@ -128,89 +129,105 @@ export default function UserProfile({
   const badgeDataList = [...sortedEarned, ...sortedLocked];
   return (
     <div className="mx-auto w-full max-w-4xl space-y-6 sm:p-4">
-      <div className="items-star flex flex-col gap-4 sm:flex-row">
-        <Avatar className="h-20 w-20">
-          <AvatarImage
-            src={`https://github.com/${username}.png`}
-            alt={username}
-          />
-          <AvatarFallback>{username[0].toUpperCase()}</AvatarFallback>
-        </Avatar>
-        <div className="flex-grow">
-          <div className="flex flex-col gap-2">
-            <div className="flex flex-row items-center gap-1">
-              <h1 className="max-w-full text-lg font-bold sm:text-2xl">
-                {username}
-              </h1>
-              <span className="font-bold text-primary">
-                (level-{totalLevel})
-              </span>
-
-              {linkedWallets.length > 0 && (
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <BadgeCheck className="ml-1 inline-flex h-5 w-5 text-yellow-500" />
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>Wallet linked</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              )}
-            </div>
-            <div className="flex flex-wrap items-center gap-3">
-              <div className="flex items-center">
-                <span className="font-mono text-sm font-medium">
-                  {Math.round(totalXp).toLocaleString()} XP
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex flex-col gap-4 sm:flex-row">
+          <Avatar className="h-20 w-20">
+            <AvatarImage
+              src={`https://github.com/${username}.png`}
+              alt={username}
+            />
+            <AvatarFallback>{username[0].toUpperCase()}</AvatarFallback>
+          </Avatar>
+          <div className="flex-grow">
+            <div className="flex flex-col gap-2">
+              <div className="flex flex-row items-center gap-1">
+                <h1 className="max-w-full text-lg font-bold sm:text-2xl">
+                  {username}
+                </h1>
+                <span className="font-bold text-primary">
+                  (level-{totalLevel})
                 </span>
-              </div>
-              {sortedEarned.length > 0 && (
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <div className="flex items-center gap-1 rounded-full bg-yellow-500/10 px-2 py-1 text-xs font-medium text-yellow-600 dark:text-yellow-500">
-                        <Trophy className="h-3.5 w-3.5" />
-                        <span>{sortedEarned.length}</span>
-                      </div>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>
-                        {sortedEarned.length} badge
-                        {sortedEarned.length !== 1 ? "s" : ""} earned
-                      </p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              )}
-              <a
-                href={`https://github.com/${username}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-secondary transition-colors hover:bg-secondary/80"
-              >
-                <Github className="h-4 w-4" />
-                <span className="sr-only">View GitHub Profile</span>
-              </a>
 
-              {linkedWallets.map((wallet, index) => {
-                const IconComponent = SUPPORTED_CHAINS[wallet.chain]?.icon;
-                return (
-                  <WalletAddressBadge
-                    key={index}
-                    address={wallet.address}
-                    icon={
-                      IconComponent ? (
-                        <IconComponent className="h-4 w-4" />
-                      ) : null
-                    }
-                    label={wallet.chain}
-                  />
-                );
-              })}
+                {linkedWallets.length > 0 && (
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <BadgeCheck className="ml-1 inline-flex h-5 w-5 text-yellow-500" />
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>Wallet linked</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                )}
+              </div>
+              <div className="flex flex-wrap items-center gap-3">
+                <div className="flex items-center">
+                  <span className="font-mono text-sm font-medium">
+                    {Math.round(totalXp).toLocaleString()} XP
+                  </span>
+                </div>
+                {sortedEarned.length > 0 && (
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <div className="flex items-center gap-1 rounded-full bg-yellow-500/10 px-2 py-1 text-xs font-medium text-yellow-600 dark:text-yellow-500">
+                          <Trophy className="h-3.5 w-3.5" />
+                          <span>{sortedEarned.length}</span>
+                        </div>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>
+                          {sortedEarned.length} badge
+                          {sortedEarned.length !== 1 ? "s" : ""} earned
+                        </p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                )}
+                <a
+                  href={`https://github.com/${username}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-secondary transition-colors hover:bg-secondary/80"
+                >
+                  <Github className="h-4 w-4" />
+                  <span className="sr-only">View GitHub Profile</span>
+                </a>
+
+                {linkedWallets.map((wallet, index) => {
+                  const IconComponent = SUPPORTED_CHAINS[wallet.chain]?.icon;
+                  return (
+                    <WalletAddressBadge
+                      key={index}
+                      address={wallet.address}
+                      icon={
+                        IconComponent ? (
+                          <IconComponent className="h-4 w-4" />
+                        ) : null
+                      }
+                      label={wallet.chain}
+                    />
+                  );
+                })}
+              </div>
             </div>
           </div>
         </div>
+        <ProfileCopyButton
+          username={username}
+          stats={stats}
+          monthlySummaries={monthlySummaries}
+          weeklySummaries={weeklySummaries}
+          roleTags={roleTags}
+          skillTags={skillTags}
+          focusAreaTags={focusAreaTags}
+          totalXp={totalXp}
+          totalLevel={totalLevel}
+          dailyActivity={dailyActivity}
+          userBadges={userBadges}
+          badgeProgress={badgeProgress}
+        />
       </div>
       <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
         {monthlySummaries.length > 0 && (

--- a/src/app/profile/[username]/page.tsx
+++ b/src/app/profile/[username]/page.tsx
@@ -37,7 +37,7 @@ export async function generateMetadata({
   const userData = await getUserProfile(username);
 
   // Get the latest weekly summary for meta description if available
-  const siteName = process.env.NEXT_PUBLIC_SITE_NAME || "Contributor Analytics";
+  const siteName = process.env.NEXT_PUBLIC_SITE_NAME || "HiScores";
   const description =
     userData?.weeklySummaries && userData.weeklySummaries.length > 0
       ? userData.weeklySummaries[0].summary || `${siteName} contributor profile`

--- a/src/app/rss.xml/route.ts
+++ b/src/app/rss.xml/route.ts
@@ -89,7 +89,7 @@ export async function GET() {
     ],
   );
 
-  const title = process.env.NEXT_PUBLIC_SITE_NAME || "Contributor Analytics";
+  const title = process.env.NEXT_PUBLIC_SITE_NAME || "HiScores";
 
   const formatItem = (
     summary: (typeof dailySummaries)[number],

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -210,7 +210,7 @@ export function Navigation() {
           <Button variant="none" size={"none"} asChild>
             <Link href="/" className="transition-opacity hover:opacity-80">
               <h1 className="text-xl font-bold">
-                {process.env.NEXT_PUBLIC_SITE_NAME || "Contributor Analytics"}
+                {process.env.NEXT_PUBLIC_SITE_NAME || "HiScores"}
               </h1>
             </Link>
           </Button>

--- a/src/components/ui/profile-copy-button.tsx
+++ b/src/components/ui/profile-copy-button.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { Copy, Check, ChevronDown } from "lucide-react";
+import { formatProfileForLLM, type ProfileData } from "@/lib/profile-formatter";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+import type { TagData } from "@/components/skill-card";
+import type { Summary } from "@/components/summary-card";
+import type { UserActivityHeatmap } from "@/lib/scoring/queries";
+import type { UserBadge } from "@/lib/badges/types";
+import type { UserStats } from "@/app/profile/[username]/components/UserProfile";
+
+interface ProfileCopyButtonProps {
+  username: string;
+  stats: UserStats;
+  monthlySummaries: Summary[];
+  weeklySummaries: Summary[];
+  roleTags: TagData[];
+  skillTags: TagData[];
+  focusAreaTags: TagData[];
+  totalXp: number;
+  totalLevel: number;
+  dailyActivity: UserActivityHeatmap[];
+  userBadges: UserBadge[];
+  badgeProgress: Record<string, number>;
+  className?: string;
+}
+
+export function ProfileCopyButton({
+  username,
+  stats,
+  monthlySummaries,
+  weeklySummaries,
+  roleTags,
+  skillTags,
+  focusAreaTags,
+  totalXp,
+  totalLevel,
+  dailyActivity,
+  userBadges,
+  badgeProgress,
+  className,
+}: ProfileCopyButtonProps) {
+  const [includeStats, setIncludeStats] = useState(true);
+  const [includeSummaries, setIncludeSummaries] = useState(true);
+  const [includeTags, setIncludeTags] = useState(true);
+  const [includeBadges, setIncludeBadges] = useState(true);
+  const [includeActivity, setIncludeActivity] = useState(true);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      const profileData: ProfileData = {
+        username,
+        totalLevel,
+        totalXp,
+        stats,
+        monthlySummaries,
+        weeklySummaries,
+        roleTags,
+        skillTags,
+        focusAreaTags,
+        dailyActivity,
+        userBadges,
+        badgeProgress,
+      };
+
+      const formattedData = formatProfileForLLM(profileData, {
+        includeStats,
+        includeSummaries,
+        includeTags,
+        includeBadges,
+        includeActivity,
+      });
+
+      await navigator.clipboard.writeText(formattedData);
+
+      setCopied(true);
+      toast.success("Profile copied to clipboard", {
+        description:
+          "The formatted profile data is ready to paste into an LLM.",
+      });
+
+      setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      console.error("Failed to copy:", error);
+      toast.error("Copy failed", {
+        description: "There was an error copying the data to your clipboard.",
+      });
+    }
+  };
+
+  return (
+    <div className={cn("flex", className)}>
+      <Button
+        variant="outline"
+        size="sm"
+        className="flex items-center gap-1.5 rounded-r-none border-r-0 px-2.5"
+        onClick={handleCopy}
+      >
+        {copied ? (
+          <Check className="h-3.5 w-3.5" />
+        ) : (
+          <Copy className="h-3.5 w-3.5" />
+        )}
+        <span className="text-xs">Copy</span>
+      </Button>
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button variant="outline" size="sm" className="rounded-l-none px-1.5">
+            <ChevronDown className="h-3.5 w-3.5" />
+            <span className="sr-only">Options</span>
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent align="end" className="w-auto p-2">
+          <div className="grid gap-3 p-2">
+            <div className="flex items-center space-x-3">
+              <Checkbox
+                id="includeStats"
+                checked={includeStats}
+                onCheckedChange={(checked) => setIncludeStats(Boolean(checked))}
+              />
+              <Label htmlFor="includeStats" className="text-sm">
+                Include Stats
+              </Label>
+            </div>
+            <div className="flex items-center space-x-3">
+              <Checkbox
+                id="includeSummaries"
+                checked={includeSummaries}
+                onCheckedChange={(checked) =>
+                  setIncludeSummaries(Boolean(checked))
+                }
+              />
+              <Label htmlFor="includeSummaries" className="text-sm">
+                Include Summaries
+              </Label>
+            </div>
+            <div className="flex items-center space-x-3">
+              <Checkbox
+                id="includeTags"
+                checked={includeTags}
+                onCheckedChange={(checked) => setIncludeTags(Boolean(checked))}
+              />
+              <Label htmlFor="includeTags" className="text-sm">
+                Include Tags
+              </Label>
+            </div>
+            <div className="flex items-center space-x-3">
+              <Checkbox
+                id="includeBadges"
+                checked={includeBadges}
+                onCheckedChange={(checked) =>
+                  setIncludeBadges(Boolean(checked))
+                }
+              />
+              <Label htmlFor="includeBadges" className="text-sm">
+                Include Badges
+              </Label>
+            </div>
+            <div className="flex items-center space-x-3">
+              <Checkbox
+                id="includeActivity"
+                checked={includeActivity}
+                onCheckedChange={(checked) =>
+                  setIncludeActivity(Boolean(checked))
+                }
+              />
+              <Label htmlFor="includeActivity" className="text-sm">
+                Include Activity
+              </Label>
+            </div>
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/src/lib/profile-formatter.ts
+++ b/src/lib/profile-formatter.ts
@@ -1,0 +1,183 @@
+import type { TagData } from "@/components/skill-card";
+import type { Summary } from "@/components/summary-card";
+import type { UserActivityHeatmap } from "@/lib/scoring/queries";
+import type { UserBadge } from "@/lib/badges/types";
+import type { UserStats } from "@/app/profile/[username]/components/UserProfile";
+
+export interface ProfileData {
+  username: string;
+  totalLevel: number;
+  totalXp: number;
+  stats: UserStats;
+  monthlySummaries: Summary[];
+  weeklySummaries: Summary[];
+  roleTags: TagData[];
+  skillTags: TagData[];
+  focusAreaTags: TagData[];
+  dailyActivity: UserActivityHeatmap[];
+  userBadges: UserBadge[];
+  badgeProgress: Record<string, number>;
+}
+
+export interface ProfileFormatOptions {
+  includeStats: boolean;
+  includeSummaries: boolean;
+  includeTags: boolean;
+  includeBadges: boolean;
+  includeActivity: boolean;
+}
+
+export function formatProfileForLLM(
+  data: ProfileData,
+  options: ProfileFormatOptions,
+): string {
+  const parts: string[] = [];
+
+  // Metadata Section (always included)
+  parts.push("## Profile Metadata");
+  parts.push("```json");
+  parts.push(
+    JSON.stringify(
+      {
+        username: data.username,
+        level: data.totalLevel,
+        total_xp: Math.round(data.totalXp),
+      },
+      null,
+      2,
+    ),
+  );
+  parts.push("```");
+  parts.push("");
+
+  // Statistics Section
+  if (options.includeStats) {
+    parts.push("## Statistics");
+    parts.push("```json");
+    parts.push(
+      JSON.stringify(
+        {
+          pull_requests: {
+            total: data.stats.totalPrs,
+            merged: data.stats.mergedPrs,
+            closed: data.stats.closedPrs,
+          },
+          code_changes: {
+            files_changed: data.stats.changedFiles,
+            lines_added: data.stats.additions,
+            lines_deleted: data.stats.deletions,
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    parts.push("```");
+    parts.push("");
+  }
+
+  // Summaries Section
+  if (options.includeSummaries) {
+    const monthlySummariesWithContent = data.monthlySummaries.filter(
+      (s) => s.summary && s.summary.trim() !== "",
+    );
+    const weeklySummariesWithContent = data.weeklySummaries.filter(
+      (s) => s.summary && s.summary.trim() !== "",
+    );
+
+    if (monthlySummariesWithContent.length > 0) {
+      parts.push("## Monthly Summaries");
+      parts.push("");
+      for (const summary of monthlySummariesWithContent) {
+        parts.push(`### ${summary.date}`);
+        parts.push(summary.summary || "");
+        parts.push("");
+      }
+    }
+
+    if (weeklySummariesWithContent.length > 0) {
+      parts.push("## Weekly Summaries");
+      parts.push("");
+      for (const summary of weeklySummariesWithContent) {
+        parts.push(`### ${summary.date}`);
+        parts.push(summary.summary || "");
+        parts.push("");
+      }
+    }
+  }
+
+  // Tags Section
+  if (options.includeTags) {
+    const formatTags = (tags: TagData[]) =>
+      tags.map((tag) => ({
+        name: tag.tagName,
+        level: tag.level,
+        xp: Math.round(tag.score),
+        progress_to_next: Math.round(tag.progress * 100),
+      }));
+
+    parts.push("## Tags & Expertise");
+    parts.push("```json");
+    parts.push(
+      JSON.stringify(
+        {
+          roles: formatTags(data.roleTags),
+          focus_areas: formatTags(data.focusAreaTags),
+          skills: formatTags(data.skillTags),
+        },
+        null,
+        2,
+      ),
+    );
+    parts.push("```");
+    parts.push("");
+  }
+
+  // Badges Section
+  if (options.includeBadges) {
+    const earnedBadges = data.userBadges.map((badge) => ({
+      type: badge.badgeType,
+      tier: badge.tier,
+      earned_at: badge.earnedAt,
+    }));
+
+    const progressBadges = Object.entries(data.badgeProgress).map(
+      ([type, value]) => ({
+        type,
+        current_value: value,
+      }),
+    );
+
+    parts.push("## Badges & Achievements");
+    parts.push("```json");
+    parts.push(
+      JSON.stringify(
+        {
+          earned: earnedBadges,
+          progress: progressBadges,
+        },
+        null,
+        2,
+      ),
+    );
+    parts.push("```");
+    parts.push("");
+  }
+
+  // Activity Section
+  if (options.includeActivity && data.dailyActivity.length > 0) {
+    const activityData = data.dailyActivity.map((day) => ({
+      date: day.date,
+      score: day.value,
+      breakdown: day.breakdown,
+    }));
+
+    parts.push("## Activity (Last 30 Days)");
+    parts.push("```json");
+    parts.push(JSON.stringify(activityData, null, 2));
+    parts.push("```");
+    parts.push("");
+  }
+
+  return parts.join("\n");
+}


### PR DESCRIPTION
## Summary
- Add copy button to contributor profile pages for exporting profile data to LLMs
- Change default site name from "Contributor Analytics" to "HiScores"

### Profile Copy Button Features
- New `ProfileCopyButton` component with split-button design (Copy + options dropdown)
- New `profile-formatter.ts` for formatting profile data as markdown with JSON blocks
- 5 toggle options (all default on): Stats, Summaries, Tags, Badges, Activity
- Includes **all** weekly/monthly summaries (not just most recent)
- Button positioned top-right, aligned with profile header

### Site Name Change
- Updated default fallback from "Contributor Analytics" to "HiScores" in:
  - `src/components/navigation.tsx` (navbar title)
  - `src/app/layout.tsx` (metadata)
  - `src/app/rss.xml/route.ts` (RSS feed title)
  - `src/app/profile/[username]/page.tsx` (profile metadata)

## Test plan
- [ ] Visit `/profile/[username]` and verify copy button appears top-right
- [ ] Click copy button and paste into text editor to verify formatted output
- [ ] Test dropdown options toggle different sections
- [ ] Verify navbar shows "HiScores" instead of "Contributor Analytics"

🤖 Generated with [Claude Code](https://claude.com/claude-code)