### PR TITLE
Fix: re-export stats after contributor summaries are generated

### DIFF
--- a/.github/workflows/run-pipelines.yml
+++ b/.github/workflows/run-pipelines.yml
@@ -288,6 +288,10 @@ jobs:
           force: "true"
           days: 1
 
+      # Re-export stats files to include contributor summaries
+      - name: Re-export stats with contributor summaries
+        run: bun run pipeline export${{ env.start_date_arg }}${{ env.end_date_arg }}${{ github.event_name == 'schedule' && ' --days 2' || '' }} -f
+
       # Determine site URL for API exports
       - name: Determine site URL
         id: site-config


### PR DESCRIPTION
## Summary
Fixes #228 

Stats files (`data/elizaos_eliza/stats/day/stats_*.json`) always had `summary: null` for contributors, even when summaries existed in the database. This was due to a pipeline ordering issue.

## Problem

The workflow had stats being exported BEFORE contributor summaries were generated:

1. `ingest-export` job → exports stats files (summaries don't exist yet → `summary: null`)
2. `generate-summaries` job → creates contributor summaries
3. Stats files never re-exported to include summaries

## Solution

Added a re-export step after summary generation completes (line 293):

```yaml
- name: Re-export stats with contributor summaries
  run: bun run pipeline export${{ env.start_date_arg }}${{ env.end_date_arg }}${{ github.event_name == 'schedule' && ' --days 2' || '' }} -f
```

**Behavior:**
- **Scheduled runs**: Re-export last 2 days only (`--days 2`)
- **Manual runs with date range**: Re-export the specified date range
- **Manual runs without dates**: Re-export everything missing

## Why Three Export Steps?

The workflow now has three export commands, each serving a purpose:

1. **Line 119**: Export everything missing (respects manual date ranges)
2. **Line 120**: Force re-export last 2 days for data completeness (April 2025 "overlap" feature)
3. **Line 293 (NEW)**: Force re-export WITH summaries after generation

This preserves the existing "overlap" safety feature while ensuring summaries are included when available.

## Test Plan
- [ ] CI checks pass
- [ ] Manual workflow run to verify summary inclusion
- [ ] Verify scheduled runs only re-export 2 days
- [ ] Verify manual runs with date range respect inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes stats files missing contributor summaries by adding a re-export step after summary generation completes.

**Key changes:**
- Added re-export command on line 293 after all summary generation completes
- For scheduled runs: re-exports last 2 days only (`--days 2`)
- For manual runs: respects date range inputs or re-exports everything if no dates specified
- Preserves existing "overlap" safety feature (line 120) for data completeness

**Why this works:**
The original workflow exported stats BEFORE summaries existed (lines 119-120 in `ingest-export` job), resulting in `summary: null`. The new re-export step runs AFTER contributor summaries are generated in the `generate-summaries` job, ensuring stats files include the actual summary text.

**Implementation is correct:**
- Uses same date range environment variables (`${{ env.start_date_arg }}${{ env.end_date_arg }}`)
- Applies `-f` flag to force overwrite of existing stats files
- Conditional logic for scheduled runs (`--days 2`) matches existing pattern on line 120

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple, well-documented addition that fixes a clear pipeline ordering bug. The new export command follows established patterns (uses same env vars, flags, and conditional logic as existing exports on lines 119-120), ensuring consistency. No breaking changes or risky operations introduced.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/run-pipelines.yml | Added re-export step after summary generation to include contributor summaries in stats files |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Workflow as GitHub Actions
    participant IngestJob as ingest-export job
    participant SummaryJob as generate-summaries job
    participant DB as SQLite Database
    participant DataFiles as Stats JSON Files

    Note over Workflow: Workflow starts (scheduled/manual)
    
    Workflow->>IngestJob: Start job
    activate IngestJob
    
    IngestJob->>DB: Run ingest pipeline
    IngestJob->>DB: Run process pipeline
    IngestJob->>DataFiles: Export stats (line 119)
    Note right of DataFiles: summaries don't exist yet<br/>contributor.summary = null
    
    IngestJob->>DataFiles: Re-export last 2 days (line 120)
    Note right of DataFiles: Still no summaries<br/>contributor.summary = null
    
    IngestJob->>Workflow: Job complete
    deactivate IngestJob
    
    Workflow->>SummaryJob: Start job (needs: ingest-export)
    activate SummaryJob
    
    SummaryJob->>DB: Import markdown summaries
    SummaryJob->>DB: Generate repository summaries
    SummaryJob->>DB: Generate contributor summaries
    Note right of DB: Summaries now exist in DB
    
    SummaryJob->>DB: Generate overall summaries
    
    SummaryJob->>DataFiles: Re-export WITH summaries (line 293 NEW)
    Note right of DataFiles: NOW includes summaries<br/>contributor.summary = actual text
    
    SummaryJob->>DataFiles: Export leaderboard JSON
    SummaryJob->>DataFiles: Export summaries to JSON API
    
    SummaryJob->>Workflow: Job complete
    deactivate SummaryJob
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->